### PR TITLE
Fix general error message typo

### DIFF
--- a/Hotels/Source/Utilities/Constants/ErrorMessage.swift
+++ b/Hotels/Source/Utilities/Constants/ErrorMessage.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 enum ErrorMessage: String {
-    case general = "Error occured"
+    case general = "Error occurred"
     case badNetwork = "Failed to load data. Try again later."
     case failedToLoadImage = "Failed to load image"
     case failedToLoadHotel = "Failed to load hotel information"


### PR DESCRIPTION
## Summary
- fix typo in general error message

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68af5d0d084883229c4cb301a3a0c217